### PR TITLE
Fix patient blip not removed after revival

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -20,11 +20,9 @@ AddEventHandler('esx_ambulancejob:revive', function(playerId)
 					xPlayer.showNotification(_U('revive_complete_award', xTarget.name, Config.ReviveReward))
 					xPlayer.addMoney(Config.ReviveReward)
 					xTarget.triggerEvent('esx_ambulancejob:revive')
-					deadPlayers[playerId] = nil
 				else
 					xPlayer.showNotification(_U('revive_complete', xTarget.name))
 					xTarget.triggerEvent('esx_ambulancejob:revive')
-					deadPlayers[playerId] = nil
 				end
 			else
 				xPlayer.showNotification(_U('player_not_unconscious'))


### PR DESCRIPTION
A blip is shown for the player in unconscious state. After revival from an EMS, the blip is not removed.

Steps to reproduce:
- A player's health is reduced to zero and calls for distress
- EMS sees a blip for the player
- EMS revives the player, player respawns

Expected behavior:
- Blip for the revived player is removed

Actual:
- Blip stays on

Root cause:

The `deadPlayers` data for the unconscious player is removed after revival, immediately set to `nil`
https://github.com/esx-framework/esx_ambulancejob/blob/0bf8a02e323f3c9e146669e9e71cff7e19d7a158/server/main.lua#L19-L27
When the unconscious player respawns, the code checks for `deadPlayers[source]`, which would already be `nil` by now.
https://github.com/esx-framework/esx_ambulancejob/blob/0bf8a02e323f3c9e146669e9e71cff7e19d7a158/server/main.lua#L53-L58
The IF check for `deadPlayers[source]` fails.
https://github.com/esx-framework/esx_ambulancejob/blob/0bf8a02e323f3c9e146669e9e71cff7e19d7a158/server/main.lua#L54
Therefore line 56 will not be called. Line 55 is also doing duplicate work to Line 23.

Solution:
- Remove the Line 23 and Line 27
https://github.com/esx-framework/esx_ambulancejob/blob/0bf8a02e323f3c9e146669e9e71cff7e19d7a158/server/main.lua#L23