### PR TITLE
esx_ambulancejob save isDied in metadata

### DIFF
--- a/esx_ambulancejob.sql
+++ b/esx_ambulancejob.sql
@@ -25,7 +25,3 @@ INSERT INTO `items` (name, label, weight) VALUES
 	('bandage','Bandage', 2),
 	('medikit','Medikit', 2)
 ;
-
-ALTER TABLE `users`
-	ADD `is_dead` TINYINT(1) NULL DEFAULT '0'
-;

--- a/localization/cs_esx_ambulancejob.sql
+++ b/localization/cs_esx_ambulancejob.sql
@@ -25,7 +25,3 @@ INSERT INTO `items` (name, label, weight) VALUES
 	('bandage','Obvaz', 2),
 	('medikit','Lékarnička', 2)
 ;
-
-ALTER TABLE `users`
-	ADD `is_dead` TINYINT(1) NULL DEFAULT '0'
-;

--- a/localization/de_esx_ambulancejob.sql
+++ b/localization/de_esx_ambulancejob.sql
@@ -25,7 +25,3 @@ INSERT INTO `items` (name, label, weight) VALUES
 	('bandage','Verband', 2),
 	('medikit','Verbandskasten', 2)
 ;
-
-ALTER TABLE `users`
-	ADD `is_dead` TINYINT(1) NULL DEFAULT '0'
-;

--- a/localization/en_esx_ambulancejob.sql
+++ b/localization/en_esx_ambulancejob.sql
@@ -25,7 +25,3 @@ INSERT INTO `items` (name, label, weight) VALUES
 	('bandage','Bandage', 2),
 	('medikit','Medikit', 2)
 ;
-
-ALTER TABLE `users`
-	ADD `is_dead` TINYINT(1) NULL DEFAULT '0'
-;

--- a/localization/fi_esx_ambulancejob.sql
+++ b/localization/fi_esx_ambulancejob.sql
@@ -25,7 +25,3 @@ INSERT INTO `items` (name, label, weight) VALUES
 	('bandage','Sideharso', 2),
 	('medikit','Ensiapupakkaus', 2)
 ;
-
-ALTER TABLE `users`
-	ADD `is_dead` TINYINT(1) NULL DEFAULT '0'
-;

--- a/localization/fr_esx_ambulancejob.sql
+++ b/localization/fr_esx_ambulancejob.sql
@@ -25,7 +25,3 @@ INSERT INTO `items` (name, label, weight) VALUES
 	('bandage','Bandage', 2),
 	('medikit','Kit de soins', 2)
 ;
-
-ALTER TABLE `users`
-	ADD `is_dead` TINYINT(1) NULL DEFAULT '0'
-;

--- a/localization/nl_esx_ambulancejob.sql
+++ b/localization/nl_esx_ambulancejob.sql
@@ -25,7 +25,3 @@ INSERT INTO `items` (name, label, weight) VALUES
 	('bandage','Verband', 2),
 	('medikit','EHBO Kit', 2)
 ;
-
-ALTER TABLE `users`
-	ADD `is_dead` TINYINT(1) NULL DEFAULT '0'
-;

--- a/localization/pl_esx_ambulancejob.sql
+++ b/localization/pl_esx_ambulancejob.sql
@@ -25,7 +25,3 @@ INSERT INTO `items` (name, label, weight) VALUES
 	('bandage','Bandaż', 2),
 	('medikit','Defibrylator', 2)
 ;
-
-ALTER TABLE `users`
-	ADD `is_dead` TINYINT(1) NULL DEFAULT '0'
-;

--- a/localization/sc_esx_ambulancejob.sql
+++ b/localization/sc_esx_ambulancejob.sql
@@ -27,7 +27,3 @@ INSERT INTO `items` (name, label, weight) VALUES
 	('bandage','医用绷带', 2),
 	('medikit','紧急治疗包', 2)
 ;
-
-ALTER TABLE `users`
-	ADD `is_dead` TINYINT(1) NULL DEFAULT '0'
-;

--- a/localization/sl_esx_ambulancejob.sql
+++ b/localization/sl_esx_ambulancejob.sql
@@ -25,7 +25,3 @@ INSERT INTO `items` (name, label, weight) VALUES
 	('bandage','Bandage', 2),
 	('medikit','Medikit', 2)
 ;
-
-ALTER TABLE `users`
-	ADD `is_dead` TINYINT(1) NULL DEFAULT '0'
-;

--- a/localization/sr_esx_ambulancejob.sql
+++ b/localization/sr_esx_ambulancejob.sql
@@ -25,7 +25,3 @@ INSERT INTO `items` (name, label, weight) VALUES
 	('bandage','Bandaže', 2),
 	('medikit','Prva Pomoć', 2)
 ;
-
-ALTER TABLE `users`
-	ADD `is_dead` TINYINT(1) NULL DEFAULT '0'
-;

--- a/server/main.lua
+++ b/server/main.lua
@@ -356,9 +356,8 @@ end)
 
 ESX.RegisterServerCallback('esx_ambulancejob:getDeathStatus', function(source, cb)
 	local xPlayer = ESX.GetPlayerFromId(source)
-	MySQL.scalar('SELECT is_dead FROM users WHERE identifier = ?', { xPlayer.identifier }, function(isDead)
-		cb(isDead)
-	end)
+	local isDead = xPlayer.getMeta("isDead") == 1
+	cb(isDead)
 end)
 
 RegisterNetEvent('esx_ambulancejob:setDeathStatus')
@@ -366,7 +365,7 @@ AddEventHandler('esx_ambulancejob:setDeathStatus', function(isDead)
 	local xPlayer = ESX.GetPlayerFromId(source)
 
 	if type(isDead) == 'boolean' then
-		MySQL.update('UPDATE users SET is_dead = ? WHERE identifier = ?', { isDead, xPlayer.identifier })
+		xPlayer.setMeta('isDead', isDead and 1 or 0)
 		isDeadState(source, isDead)
 			
 		if not isDead then


### PR DESCRIPTION
The resource uses is_dead field in DB, which is now kinda pointless because ESX can store metadata of players.