### PR TITLE
fix(client/main): fix player spawn

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -20,19 +20,6 @@ AddEventHandler('esx:onPlayerSpawn', function()
   EndDeathCam()
   if firstSpawn then
     firstSpawn = false
-
-    if Config.SaveDeathStatus then
-      while not ESX.PlayerLoaded do
-        Wait(1000)
-      end
-
-      ESX.TriggerServerCallback('esx_ambulancejob:getDeathStatus', function(shouldDie)
-        if shouldDie then
-          Wait(1000)
-          SetEntityHealth(PlayerPedId(), 0)
-        end
-      end)
-    end
   end
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -13,14 +13,15 @@ AddEventHandler('esx:onPlayerLogout', function()
 end)
 
 AddEventHandler('esx:onPlayerSpawn', function()
+  if firstSpawn then
+    firstSpawn = false
+    return
+  end
   isDead = false
   ClearTimecycleModifier()
   SetPedMotionBlur(PlayerPedId(), false)
   ClearExtraTimecycleModifier()
   EndDeathCam()
-  if firstSpawn then
-    firstSpawn = false
-  end
 end)
 
 -- Create blips

--- a/config.lua
+++ b/config.lua
@@ -5,7 +5,6 @@ Config.Debug                      = ESX.GetConfig().EnableDebug
 Config.Marker                     = {type = 1, x = 1.5, y = 1.5, z = 0.5, r = 102, g = 0, b = 102, a = 100, rotate = false}
 
 Config.ReviveReward               = 700  -- Revive reward, set to 0 if you don't want it enabled
-Config.SaveDeathStatus              = true -- Save Death Status?
 Config.LoadIpl                    = true -- Disable if you're using fivem-ipl or other IPL loaders
 
 Config.Locale = GetConvar('esx:locale', 'en')


### PR DESCRIPTION
### Description
Addition to [esx_core#1509](https://github.com/esx-framework/esx_core/pull/1509)

### Key Changes
- Remove deprecated `Config.SaveDeathStatus`. Player health is being set in `es_extended` regardless of that config entry.
- Eliminate `esx:onPlayerSpawn` race condition by ignoring first spawn.